### PR TITLE
Change the authenticate method in order to return the instance of the newly created user

### DIFF
--- a/crowd/backends.py
+++ b/crowd/backends.py
@@ -22,7 +22,7 @@ class CrowdBackend(ModelBackend):
             if user:
                 user.set_password(password)
             else:
-                self._create_new_user_from_crowd_response(username, password, content, crowd_config)
+                user = self._create_new_user_from_crowd_response(username, password, content, crowd_config)
             return user
         else:
             return None


### PR DESCRIPTION
Only after this change was made I was able to authenticate with Crowd version 2.6.5, but I'm not sure if the Crowd version is related to issue however.

As the method `_create_new_user_from_crowd_response` returns an user instance, I think that instance should be the return value of the `authenticate` method also.
