### PR TITLE
Make "superuser" and "staff" separate settings

### DIFF
--- a/crowd/backends.py
+++ b/crowd/backends.py
@@ -68,7 +68,8 @@ class CrowdBackend(ModelBackend):
         user.is_active = True
         if 'superuser' in crowd_config and crowd_config['superuser']:
             user.is_superuser = crowd_config['superuser']
-            user.is_staff = user.is_superuser
+        if 'staffuser' in crowd_config and crowd_config['staffuser']:
+            user.is_staff = crowd_config['staffuser']
         user.save()
         return user
 


### PR DESCRIPTION
This change will improve the control over the newly created user, so it is possible to decide whether an user is only a staff member, but not a superuser.
