### PR TITLE
Add dependency to httplib2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ setup(
     name='django-crowd',
     version='0.41dev',
     packages=['crowd',],
+    install_requires=['httplib2'],
     license='Creative Commons Attribution-Noncommercial-Share Alike license',
     long_description=open('README.txt').read(),
 )


### PR DESCRIPTION
The project requires httplib2 but does not specify it... so it won't even run when you try  to install it.

https://github.com/gbezyuk/django-crowd/blob/master/crowd/backends.py#L5