### PR TITLE
Save  user after using set_password

### DIFF
--- a/crowd/backends.py
+++ b/crowd/backends.py
@@ -24,6 +24,7 @@ class CrowdBackend(ModelBackend):
         if resp['status'] == '200':
             if user:
                 user.set_password(password)
+                user.save()
             else:
                 user = self._create_new_user_from_crowd_response(username, password, content, crowd_config)
             return user

--- a/crowd/tests.py
+++ b/crowd/tests.py
@@ -77,3 +77,13 @@ class CrowdBackendAuthTest(TestCase):
         user = User.objects.create_user(username=self.username, email=self.email, password=self.password)
         self.assertNotEqual(self.backend._find_existing_user('not_a_' + self.username   ), None)
         self.assertEqual(self.backend._find_existing_user(self.username).pk, user.pk)
+
+    def test_user_saved_if_exists(self):
+        user = User.objects.create_user(username=self.username, email=self.email, password=self.password)
+        old_password = user.password
+
+        self.backend._call_crowd = lambda username, password, crowd_config: ({'status': '200'}, '')
+        self.backend.authenticate(self.username, 'foo')
+
+        user.refresh_from_db()
+        self.assertNotEqual(old_password, user.password)


### PR DESCRIPTION
I think django-crowd actually doesn't work at all unless set_password has changed in some version of django where it used to save the password. I can not login using it until I tracked down the fact that it was never saving the user after it called set_password.

When you first login and use the crowd backend, it'll salt your session cookie with the in memory password from crowd. Subsequent attempts to access the page will fail because the password in the database  will be blank.

As for testing, the project needs to have a mini django app inside of a testing folder to fully test the that the django scaffolding works. The tests never call authenticate() which is where this bug was hiding. Normally you would use httmock to mock these requests but I had to monkey patch the backend object to do what I wanted.